### PR TITLE
Support more instructions and add relevant examples from Brahama paper

### DIFF
--- a/examples/hackers_delight/p10.wat
+++ b/examples/hackers_delight/p10.wat
@@ -1,0 +1,14 @@
+;; P10(x, y) Test if nlz(x) == nlz(y)
+;; where nlz is number of leading zeros.
+;; o_1 = bvand(x, y)
+;; o_2 = bvxor(x, y)
+;; res := bvule(o_1, o_2)
+
+(module
+  (func $p10 (export "p10") (param i32 i32) (result i32)
+    (i32.le_u 
+        (i32.xor (local.get 0) (local.get 1))
+        (i32.and (local.get 0) (local.get 1))
+    )
+  )
+)

--- a/examples/hackers_delight/p11.wat
+++ b/examples/hackers_delight/p11.wat
@@ -1,0 +1,17 @@
+;; P11(x, y) Test if nlz(x) < nlz(y)
+;; where nlz is number of leading zeros.
+;; o_1 = bvnot(y)
+;; o_2 = bvand(x, o_1)
+;; res := bvugt(o_2, y)
+
+(module
+  (func $p11 (export "p11") (param i32 i32) (result i32)
+    (i32.gt_u
+      (i32.and
+        (local.get 0)
+        (i32.xor (local.get 1) (i32.const -1))
+      )
+      (local.get 1)
+    )
+  )
+)

--- a/examples/hackers_delight/p12.wat
+++ b/examples/hackers_delight/p12.wat
@@ -1,0 +1,17 @@
+;; P12(x, y) Test if nlz(x) <= nlz(y)
+;; where nlz is number of leading zeros.
+;; o_1 = bvnot(x)
+;; o_2 = bvand(y, o_1)
+;; res := bvule(o_2, x)
+
+(module
+  (func $p12 (export "p12") (param i32 i32) (result i32)
+    (i32.le_u
+      (i32.and
+        (local.get 1)
+        (i32.xor (local.get 0) (i32.const -1))
+      )
+      (local.get 0)
+    )
+  )
+)

--- a/examples/hackers_delight/p13.wat
+++ b/examples/hackers_delight/p13.wat
@@ -1,0 +1,17 @@
+;; P13(x) Sign function
+;; o_1 = bvshr(x, 31)
+;; o_2 = bvneg(x)
+;; o_3 = bvshr(o_2, 31)
+;; res := bvor(o_1, o_3)
+
+(module
+  (func $p13 (export "p13") (param i32) (result i32)
+    (i32.or
+      (i32.shr_s (local.get 0) (i32.const 31))
+      (i32.shr_u
+        (i32.sub (i32.const 0) (local.get 0))
+        (i32.const 31)
+      )
+    )
+  )
+)

--- a/examples/hackers_delight/p14.wat
+++ b/examples/hackers_delight/p14.wat
@@ -1,0 +1,17 @@
+;; P14(x, y) Floor of average of two integers without over-flowing
+;; o_1 = bvand(x, y)
+;; o_2 = bvxor(x, y)
+;; o_3 = bvshr(o_2, 1)
+;; res := bvadd(o_1, o_3)
+
+(module
+  (func $p14 (export "p14") (param i32 i32) (result i32)
+    (i32.add
+      (i32.and (local.get 0) (local.get 1))
+      (i32.shr_s
+        (i32.xor (local.get 0) (local.get 1))
+        (i32.const 1)
+      )
+    )
+  )
+)

--- a/examples/hackers_delight/p15.wat
+++ b/examples/hackers_delight/p15.wat
@@ -1,0 +1,17 @@
+;; P15(x, y) Ceil of average of two integers without over-flowing
+;; o_1 = bvor(x, y)
+;; o_2 = bvxor(x, y)
+;; o_3 = bvshr(o_2, 1)
+;; res := bvadd(o_1, o_3)
+
+(module
+  (func $p15 (export "p15") (param i32 i32) (result i32)
+    (i32.sub
+      (i32.or (local.get 0) (local.get 1))
+      (i32.shr_s
+        (i32.xor (local.get 0) (local.get 1))
+        (i32.const 1)
+      )
+    )
+  )
+)

--- a/examples/hackers_delight/p16.wat
+++ b/examples/hackers_delight/p16.wat
@@ -1,0 +1,20 @@
+;; P16(x, y) Compute max of two integers
+;; o_1 = bvxor(x, y)
+;; o_2 = bvneg(bvuge(x, y))
+;; o_3 = bvand(o_1, o_2)
+;; res := bvxor(o_3, y)
+
+(module
+  (func $p16 (export "p16") (param i32 i32) (result i32)
+    (i32.xor
+      (i32.and
+        (i32.xor (local.get 0) (local.get 1))
+        (i32.sub
+          (i32.const 0)
+          (i32.ge_s (local.get 0) (local.get 1))
+        )
+      )
+      (local.get 1)
+    )
+  )
+)

--- a/examples/hackers_delight/p18.wat
+++ b/examples/hackers_delight/p18.wat
@@ -1,0 +1,29 @@
+;; P18(x) Determine if an integer is a power of 2 or not.
+;; o_1 = bvsub(x, 1)
+;; o_2 = bvand(o_1, x)
+;; o_3 = bvredor (x)
+;; o_4 = bvredor (o_2)
+;; o_5 = !(o_4)
+;; res = (o_5 && o_3)
+
+;; bvredor -> reduction or equals to 0 iff all bits are 0
+;; bvredor(x) == i32.ne (i32.const 0) (x)
+;; if x == 0, then i32.ne (i32.const 0) => 0 otherwise 1.
+
+;; !(bvredor(x)) == i32.eq (i32.const 0) (x)
+;; if x = 0, then i32.eq (i32.const 0) (x) => 1 otherwise 0.
+
+(module
+  (func $p18 (export "p18") (param i32) (result i32)
+    (i32.and 
+      (i32.ne (i32.const 0) (local.get 0)) ;; o_3
+      (i32.eq
+        (i32.const 0)
+        (i32.and 
+          (i32.sub (local.get 0) (i32.const 1))
+          (local.get 0)
+        )
+      )
+    )
+  )
+)

--- a/examples/hackers_delight/p19.wat
+++ b/examples/hackers_delight/p19.wat
@@ -1,0 +1,33 @@
+;; P19(x, m, k): Exchanging 2 fields A and B of the same register x where m is
+;; mask which identifies field B and k is number of bits from end of A to start
+;; of B
+;; o_1 = bvshr(x, k)
+;; o_2 = bvxor(x, o_1)
+;; o_3 = bvand(o_2, m)
+;; o_4 = bvshl(o_3, k)
+;; o_5 = bvxor(o_4, o_3)
+;; res = bvxor(o_5, x)
+
+(module
+  (func $p19 (export "p19") (param i32 i32 i32) (result i32) (local i32)
+    (local.set 3
+      (i32.and ;; o_3
+        (i32.xor ;; o_2
+          (local.get 0)
+          (i32.shr_u (local.get 0) (local.get 2)) ;; o_1
+        )
+        (local.get 1)
+      )
+    )
+    (i32.xor
+      (i32.xor ;; o_5 
+        (i32.shl ;; o_4
+          (local.get 3)
+          (local.get 2)
+        )
+        (local.get 3)
+      )
+      (local.get 0)
+    )
+  )
+)

--- a/examples/hackers_delight/p20.wat
+++ b/examples/hackers_delight/p20.wat
@@ -1,0 +1,35 @@
+;; P20(x): Next higher unsigned number with same number of 1 bits.
+;; o_1 = bvneg(x)
+;; o_2 = bvand(x, o_1)
+;; o_3 = bvadd(x, o_3)
+;; o_4 = bvxor(x, o_2)
+;; o_5 = bvshr(o_4, 2)
+;; o_6 = bvdiv(o_5, o_2)
+;; res = bvor(o_6, o_3)
+
+(module
+  (func $p20 (export "p20") (param i32) (result i32) (local i32 i32)
+    (local.set 1
+      (i32.and ;; o_2
+        (local.get 0)
+        (i32.sub (i32.const 0) (local.get 0)) ;; o_1
+      )
+    )
+    (local.set 2
+      (i32.add (local.get 0) (local.get 1)) ;; o_3
+    )
+    (i32.or
+      (i32.div_u ;; o_6
+        (i32.shr_u ;; o_5
+          (i32.xor ;; o_4
+            (local.get 0)
+            (local.get 2)
+          )
+          (i32.const 2)
+        )
+        (local.get 1)
+      )
+      (local.get 2)
+    )
+  )
+)

--- a/src/exec/wasmer.rs
+++ b/src/exec/wasmer.rs
@@ -27,7 +27,8 @@ impl Wasmer {
         let outputs: Vec<Output> = inputs.iter().map(|input| func.call(input)).collect();
         let test_cases = inputs.into_iter().zip(outputs.into_iter()).collect();
 
-        let return_type = func.signature().params();
+        let return_type = func.signature().returns();
+        assert_eq!(1, return_type.len(), "Doesn't support multi-value returns.");
         let mut return_type_bits = Vec::new();
         for typ in return_type {
             match typ {

--- a/src/solver/z3.rs
+++ b/src/solver/z3.rs
@@ -196,6 +196,11 @@ impl<'ctx> Converter<'ctx> {
                     let val = ast::BV::from_i64(&self.ctx, *c as i64, 32);
                     stack.push(val);
                 }
+                Instruction::I32LeU => {
+                    let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
+                    let res = lhs.bvule(&rhs);
+                    stack.push(res);
+                }
                 Instruction::Nop => {
                     // Do nothing
                 }

--- a/src/solver/z3.rs
+++ b/src/solver/z3.rs
@@ -196,9 +196,81 @@ impl<'ctx> Converter<'ctx> {
                     let val = ast::BV::from_i64(&self.ctx, *c as i64, 32);
                     stack.push(val);
                 }
+                Instruction::I32Eq => {
+                    let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
+                    let res = lhs._eq(&rhs);
+                    stack.push(res.ite(
+                        &ast::BV::from_i64(&self.ctx, 1, 32),
+                        &ast::BV::from_i64(&self.ctx, 0, 32),
+                    ));
+                }
+                Instruction::I32Ne => {
+                    let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
+                    let res = lhs._eq(&rhs);
+                    stack.push(res.ite(
+                        &ast::BV::from_i64(&self.ctx, 0, 32),
+                        &ast::BV::from_i64(&self.ctx, 1, 32),
+                    ));
+                }
+                Instruction::I32LtS => {
+                    let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
+                    let res = lhs.bvslt(&rhs);
+                    stack.push(res.ite(
+                        &ast::BV::from_i64(&self.ctx, 1, 32),
+                        &ast::BV::from_i64(&self.ctx, 0, 32),
+                    ));
+                }
+                Instruction::I32LtU => {
+                    let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
+                    let res = lhs.bvult(&rhs);
+                    stack.push(res.ite(
+                        &ast::BV::from_i64(&self.ctx, 1, 32),
+                        &ast::BV::from_i64(&self.ctx, 0, 32),
+                    ));
+                }
+                Instruction::I32GtS => {
+                    let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
+                    let res = lhs.bvsgt(&rhs);
+                    stack.push(res.ite(
+                        &ast::BV::from_i64(&self.ctx, 1, 32),
+                        &ast::BV::from_i64(&self.ctx, 0, 32),
+                    ));
+                }
+                Instruction::I32GtU => {
+                    let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
+                    let res = lhs.bvugt(&rhs);
+                    stack.push(res.ite(
+                        &ast::BV::from_i64(&self.ctx, 1, 32),
+                        &ast::BV::from_i64(&self.ctx, 0, 32),
+                    ));
+                }
+                Instruction::I32LeS => {
+                    let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
+                    let res = lhs.bvsle(&rhs);
+                    stack.push(res.ite(
+                        &ast::BV::from_i64(&self.ctx, 1, 32),
+                        &ast::BV::from_i64(&self.ctx, 0, 32),
+                    ));
+                }
                 Instruction::I32LeU => {
                     let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
                     let res: ast::Bool<'ctx> = lhs.bvule(&rhs);
+                    stack.push(res.ite(
+                        &ast::BV::from_i64(&self.ctx, 1, 32),
+                        &ast::BV::from_i64(&self.ctx, 0, 32),
+                    ));
+                }
+                Instruction::I32GeS => {
+                    let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
+                    let res = lhs.bvsge(&rhs);
+                    stack.push(res.ite(
+                        &ast::BV::from_i64(&self.ctx, 1, 32),
+                        &ast::BV::from_i64(&self.ctx, 0, 32),
+                    ));
+                }
+                Instruction::I32GeU => {
+                    let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
+                    let res = lhs.bvuge(&rhs);
                     stack.push(res.ite(
                         &ast::BV::from_i64(&self.ctx, 1, 32),
                         &ast::BV::from_i64(&self.ctx, 0, 32),

--- a/src/solver/z3.rs
+++ b/src/solver/z3.rs
@@ -164,6 +164,7 @@ impl<'ctx> Converter<'ctx> {
         let mut stack: ValueStack<'ctx> = ValueStack::new();
         for instr in func.code().elements() {
             match instr {
+                // I32 binops
                 Instruction::I32Add => {
                     let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
                     let res = lhs.bvadd(&rhs);
@@ -241,6 +242,7 @@ impl<'ctx> Converter<'ctx> {
                     let res = lhs.bvrotr(&rhs);
                     stack.push(res);
                 }
+                // local variable ops
                 Instruction::GetLocal(idx) => {
                     let val = &locals[*idx as usize];
                     stack.push(val.clone());
@@ -258,6 +260,7 @@ impl<'ctx> Converter<'ctx> {
                     let val = ast::BV::from_i64(&self.ctx, *c as i64, 32);
                     stack.push(val);
                 }
+                // I32 relops
                 Instruction::I32Eq => {
                     let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
                     let res = lhs._eq(&rhs);
@@ -338,6 +341,7 @@ impl<'ctx> Converter<'ctx> {
                         &ast::BV::from_i64(&self.ctx, 0, 32),
                     ));
                 }
+                // i32 testop
                 Instruction::I32Eqz => {
                     let val = stack.pop_as::<ast::BV<'ctx>>();
                     let res = val._eq(&ast::BV::from_i64(&self.ctx, 0, 32));
@@ -346,6 +350,7 @@ impl<'ctx> Converter<'ctx> {
                         &ast::BV::from_i64(&self.ctx, 0, 32),
                     ));
                 }
+                // i32 unops
                 Instruction::I32Clz => {
                     let val = stack.pop_as::<ast::BV<'ctx>>();
                     stack.push(clz(&self.ctx, &val));
@@ -358,6 +363,7 @@ impl<'ctx> Converter<'ctx> {
                     let val = stack.pop_as::<ast::BV<'ctx>>();
                     stack.push(popcnt(&self.ctx, &val));
                 }
+                // control instructions
                 Instruction::Nop => {
                     // Do nothing
                 }

--- a/src/solver/z3.rs
+++ b/src/solver/z3.rs
@@ -198,8 +198,11 @@ impl<'ctx> Converter<'ctx> {
                 }
                 Instruction::I32LeU => {
                     let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
-                    let res = lhs.bvule(&rhs);
-                    stack.push(res);
+                    let res: ast::Bool<'ctx> = lhs.bvule(&rhs);
+                    stack.push(res.ite(
+                        &ast::BV::from_i64(&self.ctx, 1, 32),
+                        &ast::BV::from_i64(&self.ctx, 0, 32),
+                    ));
                 }
                 Instruction::Nop => {
                     // Do nothing

--- a/src/solver/z3.rs
+++ b/src/solver/z3.rs
@@ -46,7 +46,7 @@ pub struct Converter<'ctx> {
     func_type: FunctionType,
 }
 
-pub fn ctz<'a>(ctx: &'a Context, input: &ast::BV<'a>) -> ast::BV<'a> {
+fn ctz<'a>(ctx: &'a Context, input: &ast::BV<'a>) -> ast::BV<'a> {
     let one_bit = ast::BV::from_u64(ctx, 1, 1);
 
     fn ctz_helper<'a>(
@@ -70,7 +70,7 @@ pub fn ctz<'a>(ctx: &'a Context, input: &ast::BV<'a>) -> ast::BV<'a> {
     ctz_helper(ctx, input, &one_bit, 0)
 }
 
-pub fn clz<'a>(ctx: &'a Context, input: &ast::BV<'a>) -> ast::BV<'a> {
+fn clz<'a>(ctx: &'a Context, input: &ast::BV<'a>) -> ast::BV<'a> {
     let one_bit = ast::BV::from_u64(ctx, 1, 1);
 
     fn clz_helper<'a>(
@@ -96,7 +96,7 @@ pub fn clz<'a>(ctx: &'a Context, input: &ast::BV<'a>) -> ast::BV<'a> {
     clz_helper(ctx, input, &one_bit, 0)
 }
 
-pub fn popcnt<'a>(ctx: &'a Context, input: &ast::BV<'a>) -> ast::BV<'a> {
+fn popcnt<'a>(ctx: &'a Context, input: &ast::BV<'a>) -> ast::BV<'a> {
     // As in https://stackoverflow.com/questions/39299015/sum-of-all-the-bits-in-a-bit-vector-of-z3
     let bit_width = input.get_size();
     let bits: Vec<ast::BV<'a>> = (0..bit_width).map(|i| input.extract(i, i)).collect();
@@ -221,14 +221,14 @@ impl<'ctx> Converter<'ctx> {
                     stack.push(res);
                 }
                 Instruction::I32ShrS => {
+                    // NOTE(taegyunkim): sign-replicating (arithmetic) shift right.
                     let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
-                    // TODO: Confirm whether this is signed.
                     let res = lhs.bvashr(&rhs);
                     stack.push(res);
                 }
                 Instruction::I32ShrU => {
+                    // NOTE(taegyunkim): zero-replicating (logical) shift right.
                     let (lhs, rhs) = stack.pop_pair_as::<ast::BV<'ctx>>();
-                    // TODO: Confirm whether this is unsigned.
                     let res = lhs.bvlshr(&rhs);
                     stack.push(res);
                 }

--- a/src/stoke/candidate.rs
+++ b/src/stoke/candidate.rs
@@ -1,4 +1,5 @@
 use crate::parity_wasm_utils;
+use crate::stoke::whitelist;
 use parity_wasm::elements::serialize;
 use parity_wasm::elements::{
     FuncBody, FunctionType, Instruction, Instructions, Local, Module, ValueType,
@@ -32,6 +33,8 @@ impl Candidate {
         spec_func_body: &FuncBody,
         constants: Vec<i32>,
     ) -> Self {
+        whitelist::check_instrs(spec_func_body.code().elements());
+
         let mut binary = parity_wasm_utils::build_module(
             "candidate",
             &spec_func_type,

--- a/src/stoke/transform.rs
+++ b/src/stoke/transform.rs
@@ -41,32 +41,6 @@ impl Distribution<Transform> for Standard {
     }
 }
 
-pub fn stack_cnt(instr: &Instruction) -> i32 {
-    match *instr {
-        Instruction::I32Add
-        | Instruction::I32Sub
-        | Instruction::I32Mul
-        | Instruction::I32DivS
-        | Instruction::I32DivU
-        | Instruction::I32RemS
-        | Instruction::I32RemU
-        | Instruction::I32And
-        | Instruction::I32Or
-        | Instruction::I32Xor
-        | Instruction::I32Shl
-        | Instruction::I32ShrS
-        | Instruction::I32ShrU
-        | Instruction::I32Rotl
-        | Instruction::I32Rotr
-        | Instruction::I32LeU => -1,
-        Instruction::I32Const(_) | Instruction::GetLocal(_) => 1,
-        Instruction::SetLocal(_) => -1,
-        Instruction::TeeLocal(_) => 1,
-        Instruction::Nop => 0,
-        _ => panic!("instruction {}, unimplemented", instr),
-    }
-}
-
 impl Transform {
     pub fn new(kind: TransformKind) -> Self {
         Self { kind }
@@ -95,8 +69,8 @@ impl Transform {
                 let current_instr =
                     candidate_func.instrs_mut()[transform_info.undo_indices[0]].clone();
 
-                candidate_func.dec_stack_cnt(stack_cnt(&current_instr));
-                candidate_func.inc_stack_cnt(stack_cnt(&transform_info.undo_instr));
+                candidate_func.dec_stack_cnt(whitelist::stack_cnt(&current_instr));
+                candidate_func.inc_stack_cnt(whitelist::stack_cnt(&transform_info.undo_instr));
 
                 candidate_func.instrs_mut()[transform_info.undo_indices[0]] =
                     transform_info.undo_instr.clone();
@@ -118,8 +92,8 @@ impl Transform {
         let (idx, undo_instr) = candidate_func.get_rand_instr(rng);
         let new_instr = whitelist::get_equiv_instr(rng, &undo_instr);
 
-        candidate_func.dec_stack_cnt(stack_cnt(&undo_instr));
-        candidate_func.inc_stack_cnt(stack_cnt(&new_instr));
+        candidate_func.dec_stack_cnt(whitelist::stack_cnt(&undo_instr));
+        candidate_func.inc_stack_cnt(whitelist::stack_cnt(&new_instr));
 
         let instrs = candidate_func.instrs_mut();
         instrs[idx] = new_instr.clone();
@@ -166,13 +140,22 @@ impl Transform {
             Instruction::I32ShrU => Instruction::I32ShrU,
             Instruction::I32Rotl => Instruction::I32Rotl,
             Instruction::I32Rotr => Instruction::I32Rotr,
+            Instruction::I32Eq => Instruction::I32Eq,
+            Instruction::I32Ne => Instruction::I32Ne,
+            Instruction::I32LtS => Instruction::I32LtS,
+            Instruction::I32LtU => Instruction::I32LtU,
+            Instruction::I32GtS => Instruction::I32GtS,
+            Instruction::I32GtU => Instruction::I32GtU,
+            Instruction::I32LeS => Instruction::I32LeS,
             Instruction::I32LeU => Instruction::I32LeU,
+            Instruction::I32GeS => Instruction::I32GeS,
+            Instruction::I32GeU => Instruction::I32GeU,
             Instruction::Nop => Instruction::Nop,
             Instruction::I32Const(_) => Instruction::I32Const(candidate_func.sample_i32(rng)),
             _ => panic!("Instruction not implemented."),
         };
-        candidate_func.dec_stack_cnt(stack_cnt(&undo_instr));
-        candidate_func.inc_stack_cnt(stack_cnt(&new_instr));
+        candidate_func.dec_stack_cnt(whitelist::stack_cnt(&undo_instr));
+        candidate_func.inc_stack_cnt(whitelist::stack_cnt(&new_instr));
 
         let instrs = candidate_func.instrs_mut();
         instrs[instr_idx] = new_instr.clone();
@@ -207,8 +190,8 @@ impl Transform {
         let (instr_idx, undo_instr) = candidate_func.get_rand_instr(rng);
         let new_instr: Instruction = whitelist::sample(rng, candidate_func);
 
-        candidate_func.dec_stack_cnt(stack_cnt(&undo_instr));
-        candidate_func.inc_stack_cnt(stack_cnt(&new_instr));
+        candidate_func.dec_stack_cnt(whitelist::stack_cnt(&undo_instr));
+        candidate_func.inc_stack_cnt(whitelist::stack_cnt(&new_instr));
 
         let instrs = candidate_func.instrs_mut();
         instrs[instr_idx] = new_instr.clone();

--- a/src/stoke/transform.rs
+++ b/src/stoke/transform.rs
@@ -3,7 +3,6 @@ use crate::stoke::Candidate;
 use parity_wasm::elements::Instruction;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
-use whitelist::WhitelistedInstruction;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum TransformKind {
@@ -140,41 +139,38 @@ impl Transform {
     ) -> TransformInfo {
         let (instr_idx, undo_instr) = candidate_func.get_rand_instr(rng);
 
-        // NOTE(taegyunkim): Force conversion to WhitelistedInstruction to avoid
+        // NOTE(taegyunkim): Force conversion to Instruction to avoid
         // a situation where we get a missing case leading to a bug.
-        let new_instr: Instruction = match undo_instr.clone().into() {
-            WhitelistedInstruction::GetLocal(i) => {
-                WhitelistedInstruction::GetLocal(candidate_func.get_equiv_local_idx(rng, i))
+        let new_instr: Instruction = match undo_instr {
+            Instruction::GetLocal(i) => {
+                Instruction::GetLocal(candidate_func.get_equiv_local_idx(rng, i))
             }
-            WhitelistedInstruction::SetLocal(i) => {
-                WhitelistedInstruction::SetLocal(candidate_func.get_equiv_local_idx(rng, i))
+            Instruction::SetLocal(i) => {
+                Instruction::SetLocal(candidate_func.get_equiv_local_idx(rng, i))
             }
-            WhitelistedInstruction::TeeLocal(i) => {
-                WhitelistedInstruction::SetLocal(candidate_func.get_equiv_local_idx(rng, i))
+            Instruction::TeeLocal(i) => {
+                Instruction::SetLocal(candidate_func.get_equiv_local_idx(rng, i))
             }
-            WhitelistedInstruction::I32Add => WhitelistedInstruction::I32Add,
-            WhitelistedInstruction::I32Sub => WhitelistedInstruction::I32Sub,
-            WhitelistedInstruction::I32Mul => WhitelistedInstruction::I32Mul,
-            WhitelistedInstruction::I32DivS => WhitelistedInstruction::I32DivS,
-            WhitelistedInstruction::I32DivU => WhitelistedInstruction::I32DivU,
-            WhitelistedInstruction::I32RemS => WhitelistedInstruction::I32RemS,
-            WhitelistedInstruction::I32RemU => WhitelistedInstruction::I32RemU,
-            WhitelistedInstruction::I32And => WhitelistedInstruction::I32And,
-            WhitelistedInstruction::I32Or => WhitelistedInstruction::I32Or,
-            WhitelistedInstruction::I32Xor => WhitelistedInstruction::I32Xor,
-            WhitelistedInstruction::I32Shl => WhitelistedInstruction::I32Shl,
-            WhitelistedInstruction::I32ShrS => WhitelistedInstruction::I32ShrS,
-            WhitelistedInstruction::I32ShrU => WhitelistedInstruction::I32ShrU,
-            WhitelistedInstruction::I32Rotl => WhitelistedInstruction::I32Rotl,
-            WhitelistedInstruction::I32Rotr => WhitelistedInstruction::I32Rotr,
-            WhitelistedInstruction::I32LeU => WhitelistedInstruction::I32LeU,
-            WhitelistedInstruction::Nop => WhitelistedInstruction::Nop,
-            WhitelistedInstruction::I32Const(_) => {
-                WhitelistedInstruction::I32Const(candidate_func.sample_i32(rng))
-            }
-        }
-        .into();
-
+            Instruction::I32Add => Instruction::I32Add,
+            Instruction::I32Sub => Instruction::I32Sub,
+            Instruction::I32Mul => Instruction::I32Mul,
+            Instruction::I32DivS => Instruction::I32DivS,
+            Instruction::I32DivU => Instruction::I32DivU,
+            Instruction::I32RemS => Instruction::I32RemS,
+            Instruction::I32RemU => Instruction::I32RemU,
+            Instruction::I32And => Instruction::I32And,
+            Instruction::I32Or => Instruction::I32Or,
+            Instruction::I32Xor => Instruction::I32Xor,
+            Instruction::I32Shl => Instruction::I32Shl,
+            Instruction::I32ShrS => Instruction::I32ShrS,
+            Instruction::I32ShrU => Instruction::I32ShrU,
+            Instruction::I32Rotl => Instruction::I32Rotl,
+            Instruction::I32Rotr => Instruction::I32Rotr,
+            Instruction::I32LeU => Instruction::I32LeU,
+            Instruction::Nop => Instruction::Nop,
+            Instruction::I32Const(_) => Instruction::I32Const(candidate_func.sample_i32(rng)),
+            _ => panic!("Instruction not implemented."),
+        };
         candidate_func.dec_stack_cnt(stack_cnt(&undo_instr));
         candidate_func.inc_stack_cnt(stack_cnt(&new_instr));
 
@@ -209,7 +205,7 @@ impl Transform {
         candidate_func: &mut Candidate,
     ) -> TransformInfo {
         let (instr_idx, undo_instr) = candidate_func.get_rand_instr(rng);
-        let new_instr: Instruction = WhitelistedInstruction::sample(rng, candidate_func).into();
+        let new_instr: Instruction = whitelist::sample(rng, candidate_func);
 
         candidate_func.dec_stack_cnt(stack_cnt(&undo_instr));
         candidate_func.inc_stack_cnt(stack_cnt(&new_instr));

--- a/src/stoke/transform.rs
+++ b/src/stoke/transform.rs
@@ -58,7 +58,8 @@ pub fn stack_cnt(instr: &Instruction) -> i32 {
         | Instruction::I32ShrS
         | Instruction::I32ShrU
         | Instruction::I32Rotl
-        | Instruction::I32Rotr => -1,
+        | Instruction::I32Rotr
+        | Instruction::I32LeU => -1,
         Instruction::I32Const(_) | Instruction::GetLocal(_) => 1,
         Instruction::SetLocal(_) => -1,
         Instruction::TeeLocal(_) => 1,
@@ -166,6 +167,7 @@ impl Transform {
             WhitelistedInstruction::I32ShrU => WhitelistedInstruction::I32ShrU,
             WhitelistedInstruction::I32Rotl => WhitelistedInstruction::I32Rotl,
             WhitelistedInstruction::I32Rotr => WhitelistedInstruction::I32Rotr,
+            WhitelistedInstruction::I32LeU => WhitelistedInstruction::I32LeU,
             WhitelistedInstruction::Nop => WhitelistedInstruction::Nop,
             WhitelistedInstruction::I32Const(_) => {
                 WhitelistedInstruction::I32Const(candidate_func.sample_i32(rng))

--- a/src/stoke/whitelist.rs
+++ b/src/stoke/whitelist.rs
@@ -8,7 +8,7 @@ pub fn sample<R: Rng + ?Sized>(
     // TODO(taegyunkim): Support increasing the number of locals.
     candidate_func: &mut Candidate,
 ) -> Instruction {
-    match rng.gen_range(0, 30) {
+    match rng.gen_range(0, 31) {
         0 => Instruction::I32Add,
         1 => Instruction::I32Sub,
         2 => Instruction::I32Mul,
@@ -38,6 +38,7 @@ pub fn sample<R: Rng + ?Sized>(
         26 => Instruction::I32LeU,
         27 => Instruction::I32GeS,
         28 => Instruction::I32GeU,
+        29 => Instruction::I32Eqz,
         _ => Instruction::Nop,
     }
 }
@@ -81,6 +82,7 @@ pub fn stack_cnt(instr: &Instruction) -> i32 {
         | Instruction::I32LeU
         | Instruction::I32GeS
         | Instruction::I32GeU => -1,
+        Instruction::I32Eqz => 0,
         Instruction::I32Const(_) | Instruction::GetLocal(_) => 1,
         Instruction::SetLocal(_) => -1,
         Instruction::TeeLocal(_) => 1,
@@ -105,6 +107,13 @@ const I32BINOP: [Instruction; 15] = [
     Instruction::I32ShrU,
     Instruction::I32Rotl,
     Instruction::I32Rotr,
+];
+
+#[allow(dead_code)]
+const I32UNOP: [Instruction; 3] = [
+    Instruction::I32Clz,
+    Instruction::I32Ctz,
+    Instruction::I32Popcnt,
 ];
 
 const I32RELOP: [Instruction; 10] = [
@@ -155,6 +164,7 @@ pub fn get_equiv_instr<R: Rng + ?Sized>(rng: &mut R, instr: &Instruction) -> Ins
         | Instruction::I32LeU
         | Instruction::I32GeS
         | Instruction::I32GeU => I32RELOP.choose(rng).unwrap().clone(),
+        Instruction::I32Eqz => Instruction::I32Eqz,
         Instruction::GetLocal(i) | Instruction::SetLocal(i) | Instruction::TeeLocal(i) => {
             (*VAROP.choose(rng).unwrap())(i)
         }
@@ -188,6 +198,7 @@ mod tests {
             Instruction::I32Rotl,
             Instruction::I32Rotr,
             Instruction::I32LeU,
+            Instruction::I32Eqz,
             Instruction::I32Const(1),
             Instruction::GetLocal(2),
             Instruction::SetLocal(3),

--- a/src/stoke/whitelist.rs
+++ b/src/stoke/whitelist.rs
@@ -3,54 +3,124 @@ use parity_wasm::elements::Instruction;
 use rand::seq::SliceRandom;
 use rand::Rng;
 
+const I32BINOP: [Instruction; 15] = [
+    Instruction::I32Add,
+    Instruction::I32Sub,
+    Instruction::I32Mul,
+    Instruction::I32DivS,
+    Instruction::I32DivU,
+    Instruction::I32RemS,
+    Instruction::I32RemU,
+    Instruction::I32And,
+    Instruction::I32Or,
+    Instruction::I32Xor,
+    Instruction::I32Shl,
+    Instruction::I32ShrS,
+    Instruction::I32ShrU,
+    Instruction::I32Rotl,
+    Instruction::I32Rotr,
+];
+
+const I32UNOP: [Instruction; 3] = [
+    Instruction::I32Clz,
+    Instruction::I32Ctz,
+    Instruction::I32Popcnt,
+];
+
+const I32RELOP: [Instruction; 10] = [
+    Instruction::I32Eq,
+    Instruction::I32Ne,
+    Instruction::I32LtS,
+    Instruction::I32LtU,
+    Instruction::I32GtS,
+    Instruction::I32GtU,
+    Instruction::I32LeS,
+    Instruction::I32LeU,
+    Instruction::I32GeS,
+    Instruction::I32GeU,
+];
+
+const LOCALOP: [Instruction; 3] = [
+    Instruction::GetLocal(0),
+    Instruction::SetLocal(0),
+    Instruction::TeeLocal(0),
+];
+
+const WHITELIST: [Instruction; 34] = [
+    // i32 binop
+    Instruction::I32Add,
+    Instruction::I32Sub,
+    Instruction::I32Mul,
+    Instruction::I32DivS,
+    Instruction::I32DivU,
+    Instruction::I32RemS,
+    Instruction::I32RemU,
+    Instruction::I32And,
+    Instruction::I32Or,
+    Instruction::I32Xor,
+    Instruction::I32Shl,
+    Instruction::I32ShrS,
+    Instruction::I32ShrU,
+    Instruction::I32Rotl,
+    Instruction::I32Rotr,
+    // i32 unop
+    Instruction::I32Clz,
+    Instruction::I32Ctz,
+    Instruction::I32Popcnt,
+    // i32 relop
+    Instruction::I32Eq,
+    Instruction::I32Ne,
+    Instruction::I32LtS,
+    Instruction::I32LtU,
+    Instruction::I32GtS,
+    Instruction::I32GtU,
+    Instruction::I32LeS,
+    Instruction::I32LeU,
+    Instruction::I32GeS,
+    Instruction::I32GeU,
+    // i32 testop
+    Instruction::I32Eqz,
+    // i32 const
+    Instruction::I32Const(0),
+    // local op
+    Instruction::GetLocal(0),
+    Instruction::SetLocal(0),
+    Instruction::TeeLocal(0),
+    Instruction::Nop,
+];
+
 pub fn sample<R: Rng + ?Sized>(
     rng: &mut R,
     // TODO(taegyunkim): Support increasing the number of locals.
     candidate_func: &mut Candidate,
 ) -> Instruction {
-    match rng.gen_range(0, 31) {
-        0 => Instruction::I32Add,
-        1 => Instruction::I32Sub,
-        2 => Instruction::I32Mul,
-        3 => Instruction::I32DivS,
-        4 => Instruction::I32DivU,
-        5 => Instruction::I32RemS,
-        6 => Instruction::I32RemU,
-        7 => Instruction::I32And,
-        8 => Instruction::I32Or,
-        9 => Instruction::I32Xor,
-        10 => Instruction::I32Shl,
-        11 => Instruction::I32ShrS,
-        12 => Instruction::I32ShrU,
-        13 => Instruction::I32Rotl,
-        14 => Instruction::I32Rotr,
-        15 => Instruction::I32Const(candidate_func.sample_i32(rng)),
-        16 => Instruction::GetLocal(candidate_func.sample_local_idx(rng)),
-        17 => Instruction::SetLocal(candidate_func.sample_local_idx(rng)),
-        18 => Instruction::TeeLocal(candidate_func.sample_local_idx(rng)),
-        19 => Instruction::I32Eq,
-        20 => Instruction::I32Ne,
-        21 => Instruction::I32LtS,
-        22 => Instruction::I32LtU,
-        23 => Instruction::I32GtS,
-        24 => Instruction::I32GtU,
-        25 => Instruction::I32LeS,
-        26 => Instruction::I32LeU,
-        27 => Instruction::I32GeS,
-        28 => Instruction::I32GeU,
-        29 => Instruction::I32Eqz,
-        _ => Instruction::Nop,
+    let instr = WHITELIST.choose(rng).unwrap().clone();
+    match instr {
+        Instruction::I32Const(_) => Instruction::I32Const(candidate_func.sample_i32(rng)),
+        Instruction::GetLocal(_) => Instruction::GetLocal(candidate_func.sample_local_idx(rng)),
+        Instruction::SetLocal(_) => Instruction::SetLocal(candidate_func.sample_local_idx(rng)),
+        Instruction::TeeLocal(_) => Instruction::TeeLocal(candidate_func.sample_local_idx(rng)),
+        _ => instr,
     }
 }
 
-pub fn validate(_instrs: &[Instruction]) {
-    // for instr in instrs {
-    //     // TODO(taegyunkim): Handle control flow instructions separately.
-    //     if *instr == Instruction::End {
-    //         continue;
-    //     }
-    //     let _: Instruction = instr.clone().into();
-    // }
+pub fn check(instr: &Instruction) -> bool {
+    match instr {
+        Instruction::I32Const(_)
+        | Instruction::GetLocal(_)
+        | Instruction::SetLocal(_)
+        | Instruction::TeeLocal(_)
+        | Instruction::End => true,
+        _ => WHITELIST.contains(instr),
+    }
+}
+
+pub fn check_instrs(instrs: &[Instruction]) {
+    for instr in instrs {
+        if !check(instr) {
+            panic!("{} not supported", instr);
+        }
+    }
 }
 
 pub fn stack_cnt(instr: &Instruction) -> i32 {
@@ -82,60 +152,24 @@ pub fn stack_cnt(instr: &Instruction) -> i32 {
         | Instruction::I32LeU
         | Instruction::I32GeS
         | Instruction::I32GeU => -1,
+        // i32 testop
         Instruction::I32Eqz => 0,
-        Instruction::I32Const(_) | Instruction::GetLocal(_) => 1,
+        // i32 unop
+        Instruction::I32Clz | Instruction::I32Ctz | Instruction::I32Popcnt => 0,
+        Instruction::I32Const(_) => 1,
+        Instruction::GetLocal(_) => 1,
         Instruction::SetLocal(_) => -1,
         Instruction::TeeLocal(_) => 1,
         Instruction::Nop => 0,
-        _ => panic!("instruction {}, unimplemented", instr),
+        _ => {
+            if WHITELIST.contains(instr) {
+                panic!("Forgot to implement instruction {}", instr);
+            } else {
+                panic!("Instruction {} not supported.", instr);
+            }
+        }
     }
 }
-
-const I32BINOP: [Instruction; 15] = [
-    Instruction::I32Add,
-    Instruction::I32Sub,
-    Instruction::I32Mul,
-    Instruction::I32DivS,
-    Instruction::I32DivU,
-    Instruction::I32RemS,
-    Instruction::I32RemU,
-    Instruction::I32And,
-    Instruction::I32Or,
-    Instruction::I32Xor,
-    Instruction::I32Shl,
-    Instruction::I32ShrS,
-    Instruction::I32ShrU,
-    Instruction::I32Rotl,
-    Instruction::I32Rotr,
-];
-
-#[allow(dead_code)]
-const I32UNOP: [Instruction; 3] = [
-    Instruction::I32Clz,
-    Instruction::I32Ctz,
-    Instruction::I32Popcnt,
-];
-
-const I32RELOP: [Instruction; 10] = [
-    Instruction::I32Eq,
-    Instruction::I32Ne,
-    Instruction::I32LtS,
-    Instruction::I32LtU,
-    Instruction::I32GtS,
-    Instruction::I32GtU,
-    Instruction::I32LeS,
-    Instruction::I32LeU,
-    Instruction::I32GeS,
-    Instruction::I32GeU,
-];
-
-const VAROP: [fn(n: u32) -> Instruction; 3] = [
-    Instruction::GetLocal,
-    Instruction::SetLocal,
-    Instruction::TeeLocal,
-    // Instruction::GetGlobal,
-    // Instruction::SetGlobal,
-];
 
 pub fn get_equiv_instr<R: Rng + ?Sized>(rng: &mut R, instr: &Instruction) -> Instruction {
     match *instr {
@@ -165,45 +199,56 @@ pub fn get_equiv_instr<R: Rng + ?Sized>(rng: &mut R, instr: &Instruction) -> Ins
         | Instruction::I32GeS
         | Instruction::I32GeU => I32RELOP.choose(rng).unwrap().clone(),
         Instruction::I32Eqz => Instruction::I32Eqz,
-        Instruction::GetLocal(i) | Instruction::SetLocal(i) | Instruction::TeeLocal(i) => {
-            (*VAROP.choose(rng).unwrap())(i)
+        Instruction::I32Clz | Instruction::I32Ctz | Instruction::I32Popcnt => {
+            I32UNOP.choose(rng).unwrap().clone()
         }
         Instruction::I32Const(i) => Instruction::I32Const(i),
+        Instruction::GetLocal(i) | Instruction::SetLocal(i) | Instruction::TeeLocal(i) => {
+            match *LOCALOP.choose(rng).unwrap() {
+                Instruction::GetLocal(_) => Instruction::GetLocal(i),
+                Instruction::SetLocal(_) => Instruction::SetLocal(i),
+                Instruction::TeeLocal(_) => Instruction::TeeLocal(i),
+                _ => panic!("should never happen."),
+            }
+        }
         Instruction::Nop => Instruction::Nop,
-        _ => panic!("not implemented."),
+        _ => {
+            if WHITELIST.contains(instr) {
+                panic!("Forgot to implement instruction {}", instr);
+            } else {
+                panic!("Instruction {} not supported.", instr);
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use parity_wasm::elements::Instruction;
 
     #[test]
-    fn validate_success_test() {
-        validate(&vec![
-            Instruction::I32Add,
-            Instruction::I32Sub,
-            Instruction::I32Mul,
-            Instruction::I32DivU,
-            Instruction::I32DivS,
-            Instruction::I32RemU,
-            Instruction::I32RemS,
-            Instruction::I32And,
-            Instruction::I32Or,
-            Instruction::I32Xor,
-            Instruction::I32Shl,
-            Instruction::I32ShrU,
-            Instruction::I32ShrS,
-            Instruction::I32Rotl,
-            Instruction::I32Rotr,
-            Instruction::I32LeU,
+    fn check_test() {
+        check_instrs(&WHITELIST);
+
+        for instr in &I32BINOP {
+            assert!(&WHITELIST.contains(instr));
+        }
+        for instr in &I32UNOP {
+            assert!(&WHITELIST.contains(instr));
+        }
+        for instr in &I32RELOP {
+            assert!(&WHITELIST.contains(instr));
+        }
+        for instr in &LOCALOP {
+            assert!(&WHITELIST.contains(instr));
+        }
+
+        for instr in &[
             Instruction::I32Eqz,
-            Instruction::I32Const(1),
-            Instruction::GetLocal(2),
-            Instruction::SetLocal(3),
-            Instruction::TeeLocal(4),
+            Instruction::GetLocal(0),
             Instruction::Nop,
-        ]);
+        ] {
+            assert!(&WHITELIST.contains(instr));
+        }
     }
 }

--- a/src/stoke/whitelist.rs
+++ b/src/stoke/whitelist.rs
@@ -3,225 +3,103 @@ use parity_wasm::elements::Instruction;
 use rand::seq::SliceRandom;
 use rand::Rng;
 
-// TODO(taegyunkim): Figure out a way to check all cases are covered whenever
-// this is used.
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum WhitelistedInstruction {
-    I32Add,
-    I32Sub,
-    I32Mul,
-    I32DivS,
-    I32DivU,
-    I32RemS,
-    I32RemU,
-    I32And,
-    I32Or,
-    I32Xor,
-    I32Shl,
-    I32ShrS,
-    I32ShrU,
-    I32Rotl,
-    I32Rotr,
-    I32LeU,
-    I32Const(i32),
-    GetLocal(u32),
-    SetLocal(u32),
-    TeeLocal(u32),
-    Nop,
-}
-
-impl WhitelistedInstruction {
-    pub fn sample<R: Rng + ?Sized>(
-        rng: &mut R,
-        // TODO(taegyunkim): Support increasing the number of locals.
-        candidate_func: &mut Candidate,
-    ) -> WhitelistedInstruction {
-        match rng.gen_range(0, 21) {
-            0 => WhitelistedInstruction::I32Add,
-            1 => WhitelistedInstruction::I32Sub,
-            2 => WhitelistedInstruction::I32Mul,
-            3 => WhitelistedInstruction::I32DivS,
-            4 => WhitelistedInstruction::I32DivU,
-            5 => WhitelistedInstruction::I32RemS,
-            6 => WhitelistedInstruction::I32RemU,
-            7 => WhitelistedInstruction::I32And,
-            8 => WhitelistedInstruction::I32Or,
-            9 => WhitelistedInstruction::I32Xor,
-            10 => WhitelistedInstruction::I32Shl,
-            11 => WhitelistedInstruction::I32ShrS,
-            12 => WhitelistedInstruction::I32ShrU,
-            13 => WhitelistedInstruction::I32Rotl,
-            14 => WhitelistedInstruction::I32Rotr,
-            15 => WhitelistedInstruction::I32Const(candidate_func.sample_i32(rng)),
-            16 => WhitelistedInstruction::GetLocal(candidate_func.sample_local_idx(rng)),
-            17 => WhitelistedInstruction::SetLocal(candidate_func.sample_local_idx(rng)),
-            18 => WhitelistedInstruction::TeeLocal(candidate_func.sample_local_idx(rng)),
-            19 => WhitelistedInstruction::I32LeU,
-            _ => WhitelistedInstruction::Nop,
-        }
+pub fn sample<R: Rng + ?Sized>(
+    rng: &mut R,
+    // TODO(taegyunkim): Support increasing the number of locals.
+    candidate_func: &mut Candidate,
+) -> Instruction {
+    match rng.gen_range(0, 21) {
+        0 => Instruction::I32Add,
+        1 => Instruction::I32Sub,
+        2 => Instruction::I32Mul,
+        3 => Instruction::I32DivS,
+        4 => Instruction::I32DivU,
+        5 => Instruction::I32RemS,
+        6 => Instruction::I32RemU,
+        7 => Instruction::I32And,
+        8 => Instruction::I32Or,
+        9 => Instruction::I32Xor,
+        10 => Instruction::I32Shl,
+        11 => Instruction::I32ShrS,
+        12 => Instruction::I32ShrU,
+        13 => Instruction::I32Rotl,
+        14 => Instruction::I32Rotr,
+        15 => Instruction::I32Const(candidate_func.sample_i32(rng)),
+        16 => Instruction::GetLocal(candidate_func.sample_local_idx(rng)),
+        17 => Instruction::SetLocal(candidate_func.sample_local_idx(rng)),
+        18 => Instruction::TeeLocal(candidate_func.sample_local_idx(rng)),
+        19 => Instruction::I32LeU,
+        _ => Instruction::Nop,
     }
 }
 
-impl std::fmt::Display for WhitelistedInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            WhitelistedInstruction::I32Add => write!(f, "i32.add"),
-            WhitelistedInstruction::I32Sub => write!(f, "i32.sub"),
-            WhitelistedInstruction::I32Mul => write!(f, "i32.mul"),
-            WhitelistedInstruction::I32DivS => write!(f, "i32.divs"),
-            WhitelistedInstruction::I32DivU => write!(f, "i32.divu"),
-            WhitelistedInstruction::I32RemS => write!(f, "i32.rems"),
-            WhitelistedInstruction::I32RemU => write!(f, "i32.remu"),
-            WhitelistedInstruction::I32And => write!(f, "i32.and"),
-            WhitelistedInstruction::I32Or => write!(f, "i32.or"),
-            WhitelistedInstruction::I32Xor => write!(f, "i32.xor"),
-            WhitelistedInstruction::I32Shl => write!(f, "i32.shl"),
-            WhitelistedInstruction::I32ShrS => write!(f, "i32.shrs"),
-            WhitelistedInstruction::I32ShrU => write!(f, "i32.shru"),
-            WhitelistedInstruction::I32Rotl => write!(f, "i32.rotl"),
-            WhitelistedInstruction::I32Rotr => write!(f, "i32.rotr"),
-            WhitelistedInstruction::I32Const(i) => write!(f, "i32.const {}", i),
-            WhitelistedInstruction::GetLocal(i) => write!(f, "local.get {}", i),
-            WhitelistedInstruction::SetLocal(i) => write!(f, "local.set {}", i),
-            WhitelistedInstruction::TeeLocal(i) => write!(f, "local.tee {}", i),
-            WhitelistedInstruction::I32LeU => write!(f, "i32.le_u"),
-            WhitelistedInstruction::Nop => write!(f, "nop"),
-        }
-    }
+pub fn validate(_instrs: &[Instruction]) {
+    // for instr in instrs {
+    //     // TODO(taegyunkim): Handle control flow instructions separately.
+    //     if *instr == Instruction::End {
+    //         continue;
+    //     }
+    //     let _: Instruction = instr.clone().into();
+    // }
 }
 
-impl From<Instruction> for WhitelistedInstruction {
-    fn from(instr: Instruction) -> Self {
-        match instr {
-            Instruction::I32Add => WhitelistedInstruction::I32Add,
-            Instruction::I32Sub => WhitelistedInstruction::I32Sub,
-            Instruction::I32Mul => WhitelistedInstruction::I32Mul,
-            Instruction::I32DivS => WhitelistedInstruction::I32DivS,
-            Instruction::I32DivU => WhitelistedInstruction::I32DivU,
-            Instruction::I32RemS => WhitelistedInstruction::I32RemS,
-            Instruction::I32RemU => WhitelistedInstruction::I32RemU,
-            Instruction::I32And => WhitelistedInstruction::I32And,
-            Instruction::I32Or => WhitelistedInstruction::I32Or,
-            Instruction::I32Xor => WhitelistedInstruction::I32Xor,
-            Instruction::I32Shl => WhitelistedInstruction::I32Shl,
-            Instruction::I32ShrS => WhitelistedInstruction::I32ShrS,
-            Instruction::I32ShrU => WhitelistedInstruction::I32ShrU,
-            Instruction::I32Rotl => WhitelistedInstruction::I32Rotl,
-            Instruction::I32Rotr => WhitelistedInstruction::I32Rotr,
-            Instruction::I32Const(i) => WhitelistedInstruction::I32Const(i),
-            Instruction::GetLocal(i) => WhitelistedInstruction::GetLocal(i),
-            Instruction::SetLocal(i) => WhitelistedInstruction::SetLocal(i),
-            Instruction::TeeLocal(i) => WhitelistedInstruction::TeeLocal(i),
-            Instruction::I32LeU => WhitelistedInstruction::I32LeU,
-            Instruction::Nop => WhitelistedInstruction::Nop,
-            _ => panic!("{} not implemented", instr),
-        }
-    }
-}
-
-impl Into<Instruction> for WhitelistedInstruction {
-    fn into(self) -> Instruction {
-        match self {
-            WhitelistedInstruction::I32Add => Instruction::I32Add,
-            WhitelistedInstruction::I32Sub => Instruction::I32Sub,
-            WhitelistedInstruction::I32Mul => Instruction::I32Mul,
-            WhitelistedInstruction::I32DivS => Instruction::I32DivS,
-            WhitelistedInstruction::I32DivU => Instruction::I32DivU,
-            WhitelistedInstruction::I32RemS => Instruction::I32RemS,
-            WhitelistedInstruction::I32RemU => Instruction::I32RemU,
-            WhitelistedInstruction::I32And => Instruction::I32And,
-            WhitelistedInstruction::I32Or => Instruction::I32Or,
-            WhitelistedInstruction::I32Xor => Instruction::I32Xor,
-            WhitelistedInstruction::I32Shl => Instruction::I32Shl,
-            WhitelistedInstruction::I32ShrS => Instruction::I32ShrS,
-            WhitelistedInstruction::I32ShrU => Instruction::I32ShrU,
-            WhitelistedInstruction::I32Rotl => Instruction::I32Rotl,
-            WhitelistedInstruction::I32Rotr => Instruction::I32Rotr,
-            WhitelistedInstruction::I32Const(i) => Instruction::I32Const(i),
-            WhitelistedInstruction::GetLocal(i) => Instruction::GetLocal(i),
-            WhitelistedInstruction::SetLocal(i) => Instruction::SetLocal(i),
-            WhitelistedInstruction::TeeLocal(i) => Instruction::TeeLocal(i),
-            WhitelistedInstruction::I32LeU => Instruction::I32LeU,
-            WhitelistedInstruction::Nop => Instruction::Nop,
-        }
-    }
-}
-
-pub fn validate(instrs: &[Instruction]) {
-    for instr in instrs {
-        // TODO(taegyunkim): Handle control flow instructions separately.
-        if *instr == Instruction::End {
-            continue;
-        }
-        let _: WhitelistedInstruction = instr.clone().into();
-    }
-}
-
-const I32BINOP: [WhitelistedInstruction; 16] = [
-    WhitelistedInstruction::I32Add,
-    WhitelistedInstruction::I32Sub,
-    WhitelistedInstruction::I32Mul,
-    WhitelistedInstruction::I32DivS,
-    WhitelistedInstruction::I32DivU,
-    WhitelistedInstruction::I32RemS,
-    WhitelistedInstruction::I32RemU,
-    WhitelistedInstruction::I32And,
-    WhitelistedInstruction::I32Or,
-    WhitelistedInstruction::I32Xor,
-    WhitelistedInstruction::I32Shl,
-    WhitelistedInstruction::I32ShrS,
-    WhitelistedInstruction::I32ShrU,
-    WhitelistedInstruction::I32Rotl,
-    WhitelistedInstruction::I32Rotr,
-    WhitelistedInstruction::I32LeU,
+const I32BINOP: [Instruction; 15] = [
+    Instruction::I32Add,
+    Instruction::I32Sub,
+    Instruction::I32Mul,
+    Instruction::I32DivS,
+    Instruction::I32DivU,
+    Instruction::I32RemS,
+    Instruction::I32RemU,
+    Instruction::I32And,
+    Instruction::I32Or,
+    Instruction::I32Xor,
+    Instruction::I32Shl,
+    Instruction::I32ShrS,
+    Instruction::I32ShrU,
+    Instruction::I32Rotl,
+    Instruction::I32Rotr,
 ];
 
-const VAROP: [fn(n: u32) -> WhitelistedInstruction; 3] = [
-    WhitelistedInstruction::GetLocal,
-    WhitelistedInstruction::SetLocal,
-    WhitelistedInstruction::TeeLocal,
+const VAROP: [fn(n: u32) -> Instruction; 3] = [
+    Instruction::GetLocal,
+    Instruction::SetLocal,
+    Instruction::TeeLocal,
     // Instruction::GetGlobal,
     // Instruction::SetGlobal,
 ];
 
 pub fn get_equiv_instr<R: Rng + ?Sized>(rng: &mut R, instr: &Instruction) -> Instruction {
-    let w_instr: WhitelistedInstruction = instr.clone().into();
-
-    match w_instr {
-        WhitelistedInstruction::I32Add
-        | WhitelistedInstruction::I32Sub
-        | WhitelistedInstruction::I32Mul
-        | WhitelistedInstruction::I32DivS
-        | WhitelistedInstruction::I32DivU
-        | WhitelistedInstruction::I32RemS
-        | WhitelistedInstruction::I32RemU
-        | WhitelistedInstruction::I32And
-        | WhitelistedInstruction::I32Or
-        | WhitelistedInstruction::I32Xor
-        | WhitelistedInstruction::I32Shl
-        | WhitelistedInstruction::I32ShrS
-        | WhitelistedInstruction::I32ShrU
-        | WhitelistedInstruction::I32Rotl
-        | WhitelistedInstruction::I32Rotr
-        | WhitelistedInstruction::I32LeU => *I32BINOP.choose(rng).unwrap(),
-        WhitelistedInstruction::GetLocal(i)
-        | WhitelistedInstruction::SetLocal(i)
-        | WhitelistedInstruction::TeeLocal(i) => (*VAROP.choose(rng).unwrap())(i),
-        WhitelistedInstruction::I32Const(i) => WhitelistedInstruction::I32Const(i),
-        WhitelistedInstruction::Nop => WhitelistedInstruction::Nop,
+    match *instr {
+        Instruction::I32Add
+        | Instruction::I32Sub
+        | Instruction::I32Mul
+        | Instruction::I32DivS
+        | Instruction::I32DivU
+        | Instruction::I32RemS
+        | Instruction::I32RemU
+        | Instruction::I32And
+        | Instruction::I32Or
+        | Instruction::I32Xor
+        | Instruction::I32Shl
+        | Instruction::I32ShrS
+        | Instruction::I32ShrU
+        | Instruction::I32Rotl
+        | Instruction::I32Rotr
+        | Instruction::I32LeU => I32BINOP.choose(rng).unwrap().clone(),
+        Instruction::GetLocal(i) | Instruction::SetLocal(i) | Instruction::TeeLocal(i) => {
+            (*VAROP.choose(rng).unwrap())(i)
+        }
+        Instruction::I32Const(i) => Instruction::I32Const(i),
+        Instruction::Nop => Instruction::Nop,
+        _ => panic!("not implemented."),
     }
-    .into()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use parity_wasm::elements::Instruction;
-    #[test]
-    #[should_panic]
-    fn validate_panic_test() {
-        validate(&vec![Instruction::I32Clz]);
-    }
 
     #[test]
     fn validate_success_test() {


### PR DESCRIPTION
New instructions supported
- Relational operators:  `i32.{𝖾𝗊 | 𝗇𝖾 | 𝗅𝗍_sx | 𝗀𝗍_sx | 𝗅𝖾_sx | 𝗀𝖾_sx}` where sx = s | u, signed and unsigned.
- Test operator: `i32.eqz`
- Unary operators: `i32.clz`, `i32.ctz`, `i32.popcnt`