### PR TITLE
Verfier bug fix for shift and rotate instructions

### DIFF
--- a/src/solver/z3.rs
+++ b/src/solver/z3.rs
@@ -668,11 +668,8 @@ mod tests {
                 .invoke_export("candidate", &cex_vec, &mut wasmi::NopExternals)
                 .unwrap();
             assert_ne!(spec_output, candidate_output);
-
-            // Pass --nocapture to check following output.
-            // $> cargo test -- --nocapture
-            // [I32(-1)] Some(I32(-2)) Some(I32(-3))
-            println!("{:?} {:?} {:?}", cex_vec, spec_output, candidate_output);
+            assert_eq!(spec_output, Some(wasmi::RuntimeValue::I32(0)));
+            assert_eq!(candidate_output, Some(wasmi::RuntimeValue::I32(1)));
         }
     }
 


### PR DESCRIPTION
RHS operand need to be mod 32 as in [spec tests](https://github.com/WebAssembly/testsuite/blob/da56298dddb441d1af38492ee98fe001e625d156/i32.wast#L176)